### PR TITLE
Fix cert issues by calling ssl_config.set_default_paths on the connec…

### DIFF
--- a/lib/cielo24/client.rb
+++ b/lib/cielo24/client.rb
@@ -45,6 +45,7 @@ module Cielo24
     def connect
       connection = HTTPClient.new
       connection.cookie_manager = nil
+      connection.ssl_config.set_default_paths
 
       unless self.class.options[:verify_mode] == nil
         connection.ssl_config.verify_mode = self.class.options[:verify_mode]


### PR DESCRIPTION
This fixes the PE-2655

OpenSSL::SSL::SSLError VideoCaptioning::ResubmitForCaptioningJob@high
SSL_connect returned=1 errno=0 state=error: certificate verify failed (certificate has expired)